### PR TITLE
Ensure json data are serializable for python 3.x

### DIFF
--- a/pyes/es.py
+++ b/pyes/es.py
@@ -116,6 +116,9 @@ class ESJsonEncoder(json.JSONEncoder):
             return float(str(value))
         elif isinstance(value, set):
             return list(value)
+        # For Python 3.x str is required for json serialization
+        elif isinstance(value, bytes):
+            value = value.decode("utf-8")
         # raise TypeError
         return super(ESJsonEncoder, self).default(value)
 


### PR DESCRIPTION
# WHAT
Make data json serializable for python 3.x. Convert bytes to str.