### PR TITLE
POD-10639: Add security scan pipeline (Polaris, BlackDuck, TruffleHog)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ tests/.noseids
 # IDEs
 .idea
 .project
+.DS_Store

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -78,7 +78,7 @@ pipeline {
             steps {
                 script {
                     def scanOutput = 'trufflehog_output.json'
-                    def repoPath = "${WORKSPACE}/pyes"
+                    def repoPath = "${env.WORKSPACE}/pyes"
 
                     echo "🔍 Running TruffleHog Git scan on repo path: ${repoPath}, branch: ${env.branchName}"
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,122 @@
+pipeline {
+    agent { label 'azure-linux-ubuntu-18' }
+    options {
+        skipStagesAfterUnstable()
+        disableConcurrentBuilds()
+    }
+    stages {
+        stage("Clone Git Repo") {
+            steps {
+                cleanWs()
+                script {
+                    def branchName = env.CHANGE_BRANCH ?: env.BRANCH_NAME
+                    env.branchName = branchName
+                    echo "Using branch/commit: ${env.BRANCH_NAME}"
+                }
+                checkout([
+                    $class: 'GitSCM',
+                    branches: [[name: "refs/heads/${env.branchName}"]],
+                    doGenerateSubmoduleConfigurations: false,
+                    extensions: [
+                        [$class: 'RelativeTargetDirectory', relativeTargetDir: 'pyes'],
+                        [$class: 'CloneOption', shallow: true, depth: 1, noTags: false]
+                    ],
+                    submoduleCfg: [],
+                    userRemoteConfigs: [[credentialsId: 'github-app-podio-jm', url: 'https://github.com/podio/pyes.git']]
+                ])
+            }
+        }
+
+        stage('Polaris') {
+            environment {
+                BRIDGE_POLARIS_SERVERURL = "https://polaris.blackduck.com"
+                BRIDGE_POLARIS_ACCESSTOKEN = credentials('blackduck-api-token')
+                BRIDGE_POLARIS_APPLICATION_NAME = "Podio-Podio"
+                BRIDGE_POLARIS_PROJECT_NAME = "pyes"
+                BRIDGE_POLARIS_BRANCH_NAME = "${env.branchName}"
+                BRIDGE_POLARIS_ASSESSMENT_TYPES = "SAST"
+            }
+            steps {
+                dir('pyes') {
+                    script {
+                        status = sh returnStatus: true, script: '''
+                            bridge-cli --stage polaris
+                        '''
+                        if (status == 8) {
+                            unstable 'Policy violation'
+                        } else if (status != 0) {
+                            error 'Bridge CLI failure'
+                        }
+                    }
+                }
+            }
+        }
+
+        stage('BlackDuckSCA') {
+            environment {
+                BRIDGE_BLACKDUCKSCA_URL = "https://progresssoftware.app.blackduck.com"
+                BRIDGE_BLACKDUCKSCA_TOKEN = credentials('blackduck-sca-token')
+                BRIDGE_BLACKDUCKSCA_SCAN_FAILURE_SEVERITIES = "CRITICAL"
+                BRIDGE_BLACKDUCKSCA_SCAN_FULL = "true"
+                BRIDGE_DETECT_ARGS = "--detect.project.name=DX-Podio-pyes --detect.project.version.name=${env.branchName} --detect.project.version.update=true --detect.project.version.distribution=SAAS --detect.project.group.name=Podio-Podio"
+            }
+            steps {
+                dir('pyes') {
+                    script {
+                        status = sh returnStatus: true, script: '''
+                            bridge-cli --stage blackducksca
+                        '''
+                        if (status != 0) {
+                            error 'BlackDuck SCA Scan failed'
+                        }
+                    }
+                }
+            }
+        }
+
+        stage('TruffleHog Scan') {
+            steps {
+                script {
+                    def scanOutput = 'trufflehog_output.json'
+                    def repoPath = "${WORKSPACE}/pyes"
+
+                    echo "🔍 Running TruffleHog Git scan on repo path: ${repoPath}, branch: ${env.branchName}"
+
+                    def scanExitCode = sh(returnStatus: true, script: """
+                        docker run --rm -v "${repoPath}:/usr/src" \
+                          artifacts.progress.com/ci-local-docker/trufflesecurity/trufflehog:3.88.29-amd64 \
+                          git file:/usr/src \
+                          --branch="${env.branchName}" \
+                          --results=verified,unknown \
+                          --force-skip-binaries \
+                          --force-skip-archives \
+                          --json \
+                          --no-update \
+                          > "${scanOutput}"
+
+                        echo "📄 TruffleHog scan completed. Output saved to ${scanOutput}"
+                        if grep -q '"SourceMetadata"' "${scanOutput}"; then
+                            echo "❌ TruffleHog found potential secrets!"
+                            cat "${scanOutput}"
+                            exit 1
+                        else
+                            echo "✅ No secrets found."
+                        fi
+                    """)
+
+                    if (scanExitCode != 0) {
+                        error("❌ TruffleHog scan failed, potential secrets detected in the repository.")
+                    }
+                }
+            }
+            post {
+                always {
+                    archiveArtifacts artifacts: 'trufflehog_output.json', fingerprint: true, allowEmptyArchive: true
+                }
+                success {
+                    echo "✅ TruffleHog scan passed - No secrets detected."
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
**WHAT**

Added a Jenkinsfile and updated .gitignore in the pyes repository:

Polaris — SAST scan via Black Duck Bridge CLI
BlackDuck SCA — software composition analysis for critical vulnerabilities, project tracked as DX-Podio-pyes
TruffleHog — secret detection scanning the git history for leaked credentials or tokens
gitignore — updated to exclude .DS_Store

**WHY**

Security scanning coverage is being rolled out across all Podio repositories as part of a standardisation effort. This aligns pyes with the setup already in place for globiflow-hookqueue, js-runner-go, rails-erb-check, podio-rb, terraform-infrastructure, dr-watchdog, simpleconfig-encrypt, and valideer

Jira: [POD-10639]

**RISK**

Low. This is a net-new file — no existing code was modified. The pipeline is purely additive and has no effect on the application itself.

**TESTING**

Jenkinsfile follows the same structure already validated and running in other Podio repositories
bridge-cli runs inside dir('pyes') to ensure scans target the checked-out source directory
Shell variables are quoted to handle paths with spaces and branch names with special characters
.DS_Store added to .gitignore to prevent accidental commits
PR reviewer can validate by triggering the pipeline on this branch and confirming all three scan stages execute and report results correctly